### PR TITLE
[Gas City Path-B trial] Add registration automation (CompatHelper + TagBot + CHANGELOG)

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,37 @@
+name: CompatHelper
+
+# Keep the [compat] bounds of GPUFiniteFieldMatrices.jl current by opening update PRs.
+# Runs on a daily schedule and on demand. Authenticates with the built-in
+# GITHUB_TOKEN; if a DOCUMENTER_KEY deploy key is also present it is reused so the
+# opened PR re-triggers CI. With only GITHUB_TOKEN the action still works (the PR
+# simply will not re-trigger workflows).
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+      - name: Install CompatHelper
+        run: |
+          import Pkg
+          Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,42 @@
+name: TagBot
+
+# Create git tags and GitHub releases for GPUFiniteFieldMatrices.jl when a version is
+# merged into the General registry. Self-gating: the job only runs in response to
+# the registry's "JuliaTagBot" comment (or a manual dispatch), so it stays inert
+# until the package is registered. Uses the built-in GITHUB_TOKEN.
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        description: 'Number of days to look back for missed releases'
+        default: '3'
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+jobs:
+  TagBot:
+    # Only the registry's TagBot comment (or a manual run) triggers a release, so
+    # this is inert on a fresh, unregistered package.
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to `GPUFiniteFieldMatrices.jl` are documented in this file.
+
+The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). On each
+release, move the `[Unreleased]` entries into a new `[x.y.z] - YYYY-MM-DD`
+section — TagBot copies that section into the GitHub release notes.
+
+## [Unreleased]
+
+### Added
+
+- Initial package scaffold.
+
+[Unreleased]: https://github.com/UCSD-computational-number-theory/GPUFiniteFieldMatrices.jl/commits/main


### PR DESCRIPTION
## ⚠️ HELD OPEN for review — do **not** merge

This is a **Path-B (existing-repo augment) trial** from the Gas City `julia-tools`
pack, validation bead **gcs-4os.8**. Per the epic merge rule, a PR opened against a
Julia target repo stays open for overseer review.

## What this adds (additive only)

| File | Why | Runs on this PR? |
|------|-----|------------------|
| `.github/workflows/CompatHelper.yml` | Opens daily PRs to keep `[compat]` bounds current — needed for General registration. | No (schedule + `workflow_dispatch` only) |
| `.github/workflows/TagBot.yml` | Tags + GitHub releases once registered; self-gating, inert until then. | No (`issue_comment` + `workflow_dispatch` only) |
| `CHANGELOG.md` | Keep-a-Changelog seed; TagBot copies the released section into release notes. | n/a |

Both workflows are schedule/comment-gated, so **they add zero new checks to this
PR** — CI here is your existing `CI.yml`, unchanged. Action pins verified current
at open time: `julia-actions/setup-julia@v3` (v3.0.2), `JuliaRegistries/TagBot@v1`
(v1.25.7).

## What this deliberately does NOT touch (augment-not-clobber)

Nothing bespoke was modified: `Project.toml`, `CI.yml`, `src/`, `test/` (incl.
your `test/Quality/` Aqua/JET/formatter/staticlint scripts), `LICENSE`,
`.gitignore`, `README.md`, `Makefile`, `format.md` are all untouched.

## Findings for the Path-B formula epic (gcs-w17) — intentionally skipped here

A naive "scaffold everything" would have reddened CI and fought this repo's
existing setup. Skipped, with reasons:

- **Blue `.JuliaFormatter.toml` + `.pre-commit-config.yaml` + `pre-commit.yml`** —
  this repo formats to JuliaFormatter's **default** style (`test/Quality/formatter.jl`
  calls `format_text` with no style; see `format.md`), not `blue`. A blue pre-commit
  gate would reformat the whole codebase and red CI. Path-B must detect the
  repo's existing style and not impose a conflicting one.
- **`Documentation.yml` + `docs/`** — a hard-gated Documenter build with
  `checkdocs=:all` over the current (largely undocumented) GPU code would fail.
  Path-B should add docs only when the docstring coverage supports a green build.
- **Greenfield `CI.yml`** — kept your bespoke `CI.yml`; not replaced.

Generated as part of Gas City validation (gcs-4os.8). 🤖